### PR TITLE
Added ability to configure scan mode

### DIFF
--- a/beaconsuedtirolsdk/src/main/java/it/bz/beacon/beaconsuedtirolsdk/NearbyBeaconManager.java
+++ b/beaconsuedtirolsdk/src/main/java/it/bz/beacon/beaconsuedtirolsdk/NearbyBeaconManager.java
@@ -199,6 +199,14 @@ public class NearbyBeaconManager implements SecureProfileListener {
     }
 
     /**
+     * Configure ScanMode for PromximityManager
+     */
+    public void configureScanMode(ScanMode scanMode) {
+        proximityManager.configuration()
+            .scanMode(scanMode);
+    }
+
+    /**
      * Stops scanning.
      */
     public void stopScanning() {

--- a/beaconsuedtirolsdk/src/main/java/it/bz/beacon/beaconsuedtirolsdk/NearbyBeaconManager.java
+++ b/beaconsuedtirolsdk/src/main/java/it/bz/beacon/beaconsuedtirolsdk/NearbyBeaconManager.java
@@ -6,13 +6,7 @@ import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
 import android.content.pm.PackageManager;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
-import androidx.work.Constraints;
-import androidx.work.PeriodicWorkRequest;
-import androidx.work.WorkManager;
-
+import com.kontakt.sdk.android.ble.configuration.ScanMode;
 import com.kontakt.sdk.android.ble.connection.OnServiceReadyListener;
 import com.kontakt.sdk.android.ble.device.BeaconRegion;
 import com.kontakt.sdk.android.ble.device.EddystoneNamespace;
@@ -33,6 +27,12 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+import androidx.work.Constraints;
+import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkManager;
 import it.bz.beacon.beaconsuedtirolsdk.auth.TrustedAuth;
 import it.bz.beacon.beaconsuedtirolsdk.data.entity.Beacon;
 import it.bz.beacon.beaconsuedtirolsdk.data.event.LoadAllBeaconsEvent;

--- a/beaconsuedtirolsdk/src/main/java/it/bz/beacon/beaconsuedtirolsdk/NearbyBeaconManager.java
+++ b/beaconsuedtirolsdk/src/main/java/it/bz/beacon/beaconsuedtirolsdk/NearbyBeaconManager.java
@@ -34,6 +34,7 @@ import androidx.work.Constraints;
 import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
 import it.bz.beacon.beaconsuedtirolsdk.auth.TrustedAuth;
+import it.bz.beacon.beaconsuedtirolsdk.configuration.BluetoothMode;
 import it.bz.beacon.beaconsuedtirolsdk.data.entity.Beacon;
 import it.bz.beacon.beaconsuedtirolsdk.data.event.LoadAllBeaconsEvent;
 import it.bz.beacon.beaconsuedtirolsdk.data.event.LoadBeaconEvent;
@@ -199,11 +200,23 @@ public class NearbyBeaconManager implements SecureProfileListener {
     }
 
     /**
-     * Configure ScanMode for PromximityManager
+     * Configure BluetoothMode for PromximityManager
      */
-    public void configureScanMode(ScanMode scanMode) {
+    public void configureScanMode(BluetoothMode bluetoothMode) {
         proximityManager.configuration()
-            .scanMode(scanMode);
+            .scanMode(convertScanMode(bluetoothMode));
+    }
+
+    private ScanMode convertScanMode(BluetoothMode bluetoothMode) {
+        switch (bluetoothMode) {
+            case low_power:
+                return ScanMode.LOW_POWER;
+            default:
+            case balanced:
+                return ScanMode.BALANCED;
+            case low_latency:
+                return ScanMode.LOW_LATENCY;
+        }
     }
 
     /**

--- a/beaconsuedtirolsdk/src/main/java/it/bz/beacon/beaconsuedtirolsdk/configuration/BluetoothMode.java
+++ b/beaconsuedtirolsdk/src/main/java/it/bz/beacon/beaconsuedtirolsdk/configuration/BluetoothMode.java
@@ -1,0 +1,5 @@
+package it.bz.beacon.beaconsuedtirolsdk.configuration;
+
+public enum BluetoothMode {
+    low_power, balanced, low_latency
+}


### PR DESCRIPTION
Hello @Piiit!

I've made a simple PR to add the possibility to configure ScanMode for proximity manager (from Kontakt)
Reference is here: https://developer.kontakt.io/mobile/android/qsg/usage/

Do you think you can merge it? I need to try out _LOWLATENCY_ mode to improve performances on beacons discovery